### PR TITLE
[Week 6] Fix named target ports for cat and meow services

### DIFF
--- a/week6/helm/raw-files/cat-application.yaml
+++ b/week6/helm/raw-files/cat-application.yaml
@@ -45,4 +45,4 @@ spec:
       # The port exposed on the target Pods
       # targetPort: 8080
       # You can also use the port name as defined in the Deployment/Pod Spec for this exposed port
-      name: my-exposed-port
+      targetPort: my-exposed-port

--- a/week6/helm/raw-files/meow-application.yaml
+++ b/week6/helm/raw-files/meow-application.yaml
@@ -52,4 +52,4 @@ spec:
       # The port exposed on the target Pods
       # targetPort: 8080
       # You can also use the port name as defined in the Deployment/Pod Spec for this exposed port
-      name: my-exposed-port
+      targetPort: my-exposed-port

--- a/week6/suggested-solutions/working-cat-application/templates/service.yaml
+++ b/week6/suggested-solutions/working-cat-application/templates/service.yaml
@@ -10,4 +10,4 @@ spec:
     app.kubernetes.io/name: {{ include "cat-application.name" . }}
   ports:
     - port: {{ .Values.service.port }}
-      name: {{ .Values.containerPortName }}
+      targetPort: {{ .Values.containerPortName }}

--- a/week6/suggested-solutions/working-meow-application/templates/service.yaml
+++ b/week6/suggested-solutions/working-meow-application/templates/service.yaml
@@ -10,4 +10,4 @@ spec:
     app.kubernetes.io/name: {{ include "meow-application.name" . }}
   ports:
     - port: {{ .Values.service.port }}
-      name: {{ .Values.containerPortName }}
+      targetPort: {{ .Values.containerPortName }}


### PR DESCRIPTION
For the service ports spec, in order to target ports named in the deployment spec, we should use
```yml
targetPort: port-name
```
instead of
```yml
name: port-name
```
.

The latter just names the service port instead of specifying the target port name. The example specs are working only because the service port (8080) happens to be the same as the target port in the examples, and the target port gets defaulted to the service port when not specified. If we try setting the service port to 80 (which lets us omit the port in `CATS_URL`), the service breaks.

Reference: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service